### PR TITLE
fix: docblocks not declaring facade methods static

### DIFF
--- a/src/Xml/Facade.php
+++ b/src/Xml/Facade.php
@@ -3,11 +3,11 @@
 namespace Orchestra\Parser\Xml;
 
 /**
- * @method \Laravie\Parser\Document extract(string $content)
- * @method \Laravie\Parser\Document load(string $filename)
- * @method \Laravie\Parser\Document local(string $filename)
- * @method \Laravie\Parser\Document remote(string $filename)
- * @method \Laravie\Parser\Document via(\SimpleXMLElement $xml)
+ * @method static \Laravie\Parser\Document extract(string $content)
+ * @method static \Laravie\Parser\Document load(string $filename)
+ * @method static \Laravie\Parser\Document local(string $filename)
+ * @method static \Laravie\Parser\Document remote(string $filename)
+ * @method static \Laravie\Parser\Document via(\SimpleXMLElement $xml)
  *
  * @see \Orchestra\Parser\Xml\Reader
  */


### PR DESCRIPTION
Noticed that the Docblocks on the facade weren't marked at static, so Intellisense wasn't suggesting autocompletions.