### PR TITLE
fix: remove callable type hint from filter resolver

### DIFF
--- a/src/Xml/Document.php
+++ b/src/Xml/Document.php
@@ -39,7 +39,7 @@ class Document extends BaseDocument
      *
      * @return mixed
      */
-    protected function callFilterResolver(callable $resolver, $value)
+    protected function callFilterResolver($resolver, $value)
     {
         return $this->app->call($resolver, ['value' => $value]);
     }


### PR DESCRIPTION
PHP Version: 8.0
laravie/parser v2.1.4
orchestra/parser v6.1.0

Seems to be a mismatch on type hints. I'd assume it was ok to be more specific but it doesn't seem so.

```
Declaration of Orchestra\Parser\Xml\Document::callFilterResolver(callable $resolver, $value) must be compatible with Laravie\Parser\Document::callFilterResolver($resolver, $value)

  at vendor/orchestra/parser/src/Xml/Document.php:40
     36▕      * @param  mixed  $value
     37▕      *
     38▕      * @return mixed
     39▕      */
  ➜  40▕     protected function callFilterResolver(callable $resolver, $value)
     41▕     {
     42▕         return $this->app->call($resolver, ['value' => $value]);
     43▕     }
     44▕ }

```