### PR TITLE
[11.x] Support Laravel 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Laravel    | Parser
  10.x      | 8.x
  11.x      | 9.x
  12.x      | 10.x
+ 13.x      | 11.x
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -28,15 +28,15 @@
         }
     },
     "require": {
-        "php": "^8.2",
-        "illuminate/container": "^12.0",
-        "laravie/parser": "^3.0"
+        "php": "^8.3",
+        "illuminate/container": "^13.0",
+        "laravie/parser": "dev-l13-compatibility"
     },
     "require-dev": {
-        "laravel/pint": "^1.21",
-        "orchestra/testbench": "^10.0",
+        "laravel/pint": "^1.29",
+        "orchestra/testbench": "^11.0",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": "^13.1.3"
     },
     "extra": {
         "branch-alias": {
@@ -72,6 +72,12 @@
     "config": {
         "sort-packages": true
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/laravel-shift/parser.git"
+        }
+    ],
     "prefer-stable": true,
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
**WARNING**

This package depends on `laravie/parser`, which is not yet compatible with Laravel 13.
To work around this, this PR temporarily relies on a branch generated by Laravel Shift (see: https://github.com/laravie/parser/pull/39).
Once `laravie/parser` adds official Laravel 13 support, this package can be updated accordingly with minimal effort.